### PR TITLE
Create CSharp Namer plugin stub and more default files

### DIFF
--- a/autorest/codegen/azure_functions_templates/csharp/vscode/extensions.json.jinja2
+++ b/autorest/codegen/azure_functions_templates/csharp/vscode/extensions.json.jinja2
@@ -1,0 +1,8 @@
+{% raw %}
+{
+  "recommendations": [
+    "ms-azuretools.vscode-azurefunctions",
+    "ms-dotnettools.csharp"
+  ]
+}
+{% endraw %}

--- a/autorest/codegen/serializers/azure_functions/csharp/__init__.py
+++ b/autorest/codegen/serializers/azure_functions/csharp/__init__.py
@@ -58,7 +58,7 @@ class AzureFunctionsCSharpSerializer(AzureFunctionsSerializer):
 
         _LOGGER.debug("Generating Function App contents")
         self._serialize_and_write_function_app_contents(
-            env=self.azure_functions_templates_env, function_app_path=self.function_app_path)
+            env=self.azure_functions_templates_env, code_model=self.code_model, function_app_path=self.function_app_path)
 
         # Writes the model folder
         _LOGGER.debug("Generating python model folders")
@@ -83,7 +83,7 @@ class AzureFunctionsCSharpSerializer(AzureFunctionsSerializer):
         #self.autorest_api.write_file(models_path / Path("__init__.py"), ModelInitSerializer(code_model=code_model, env=env).serialize())
 
     def _serialize_and_write_function_app_contents(
-            self, env: Environment, function_app_path: Path) -> None:
+            self, env: Environment, code_model: CodeModel, function_app_path: Path) -> None:
         """Create the top level function all files.
 
         This generates the following files -
@@ -119,7 +119,7 @@ class AzureFunctionsCSharpSerializer(AzureFunctionsSerializer):
 
         # Write the csproj file in the Azure Functions App folder
         self.autorest_api.write_file(
-            function_app_path / Path("app.csproj"), azure_functions_serializer.serialize_csproj_file())
+            function_app_path / Path(code_model.namespace + ".csproj"), azure_functions_serializer.serialize_csproj_file())
 
         # Write the .funcignore file in the Azure Functions App folder
         # self.autorest_api.write_file(

--- a/autorest/codegen/serializers/azure_functions/csharp/__init__.py
+++ b/autorest/codegen/serializers/azure_functions/csharp/__init__.py
@@ -88,9 +88,10 @@ class AzureFunctionsCSharpSerializer(AzureFunctionsSerializer):
 
         This generates the following files -
         - host.json
-        # - requirments.txt
-        # - local.settings.json
+        - local.settings.json
         - .gitignore
+        - app.csproj
+        - .vscode files
         # - README.md
 
         :param code_model:
@@ -107,12 +108,6 @@ class AzureFunctionsCSharpSerializer(AzureFunctionsSerializer):
             function_app_path / Path("host.json"),
             azure_functions_serializer.serialize_host_json_file()
         )
-
-        # Write the requirments.txt file in the Azure Functions App folder
-        # self.autorest_api.write_file(
-        #        function_app_path / Path("requirements.txt"),
-        #        azure_functions_serializer.serialize_requirements_txt_file()
-        # )
 
         # Write the local.settings.json file in the Azure Functions App folder
         self.autorest_api.write_file(function_app_path / Path("local.settings.json"),
@@ -156,11 +151,8 @@ class AzureFunctionsCSharpSerializer(AzureFunctionsSerializer):
         azure_functions_serializer = AzureFunctionsCSharpAppSerializer(
             env=env, async_mode=False)
 
-        # self.autorest_api.write_file(
-        #        function_app_path / Path(_VSCODE_FOLDER_NAME) /
-        #        Path("extensions.json"),
-        #        azure_functions_serializer.serialize_extensions_json_file()
-        # )
+        self.autorest_api.write_file(function_app_path / Path(_VSCODE_FOLDER_NAME) / Path(
+            "extensions.json"), azure_functions_serializer.serialize_extensions_json_file())
 
     def _serialize_and_write_functions(
             self, code_model: CodeModel, env: Environment,
@@ -238,17 +230,13 @@ class AzureFunctionsCSharpAppSerializer(object):
     #    template = self.env.get_template("proxies.json.jinja2")
     #    return template.render()
 
-    # def serialize_requirements_txt_file(self):
-    #    template = self.env.get_template("requirements.txt.jinja2")
-    #    return template.render()
-
     # def serialize_readme_md_file(self, function_app_path):
     #    template = self.env.get_template("readme.md.jinja2")
     #    return template.render(function_app_name=function_app_path)
 
-    # def serialize_extensions_json_file(self):
-    #    template = self.env.get_template("vscode-extensions.json.jinja2")
-    #    return template.render()
+    def serialize_extensions_json_file(self):
+        template = self.env.get_template("vscode/extensions.json.jinja2")
+        return prettify_json(template.render())
 
     # def serialize_launch_json_file(self):
     #    template = self.env.get_template("vscode-launch.json.jinja2")

--- a/autorest/jsonrpc/server.py
+++ b/autorest/jsonrpc/server.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @dispatcher.add_method
 def GetPluginNames():
-    return ["codegen", "m2r", "namer", "multiapiscript"]
+    return ["codegen", "m2r", "namer", "namercsharp", "multiapiscript"]
 
 
 @dispatcher.add_method
@@ -34,6 +34,8 @@ def Process(plugin_name: str, session_id: str) -> bool:
             from ..m2r import M2R as PluginToLoad
         elif plugin_name == "namer":
             from ..namer import Namer as PluginToLoad  # type: ignore
+        elif plugin_name == "namercsharp":
+            from ..namer.csharp import Namer as PluginToLoad  # type: ignore
         elif plugin_name == "codegen":
             from ..codegen import CodeGenerator as PluginToLoad  # type: ignore
         elif plugin_name == "multiapiscript":

--- a/autorest/namer/csharp/__init__.py
+++ b/autorest/namer/csharp/__init__.py
@@ -1,0 +1,25 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+"""The namer autorest plugin.
+"""
+import logging
+from typing import Dict, Any
+
+from .. import YamlUpdatePlugin
+from .name_converter import NameConverter
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Namer(YamlUpdatePlugin):
+    """Add CSharp naming information.
+    """
+
+    def update_yaml(self, yaml_data: Dict[str, Any]) -> None:
+        """Convert in place the YAML str.
+        """
+        NameConverter.convert_yaml_names(yaml_data)

--- a/autorest/namer/csharp/name_converter.py
+++ b/autorest/namer/csharp/name_converter.py
@@ -1,0 +1,227 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import re
+from typing import cast, Any, Dict, List, Match, Optional
+from .python_mappings import basic_latin_chars, reserved_words, PadType
+
+
+class NameConverter:
+    @staticmethod
+    def convert_yaml_names(yaml_data: Dict[str, Any]) -> None:
+        NameConverter._convert_language_default_python_case(yaml_data)
+        yaml_data["info"]["python_title"] = NameConverter._to_valid_python_name(
+            name=yaml_data["info"]["title"].replace(" ", ""), convert_name=True
+        )
+        yaml_data["info"]["python_title"] = NameConverter._to_valid_python_name(
+            name=yaml_data["info"]["title"].replace(" ", ""), convert_name=True
+        )
+        yaml_data['info']['pascal_case_title'] = yaml_data["language"]["default"]["name"]
+        if yaml_data['info'].get("description"):
+            if yaml_data["info"]["description"][-1] != ".":
+                yaml_data["info"]["description"] += "."
+        else:
+            yaml_data["info"]["description"] = yaml_data['info']['pascal_case_title'] + "."
+        NameConverter._convert_schemas(yaml_data['schemas'])
+        NameConverter._convert_operation_groups(yaml_data['operationGroups'], yaml_data['info']['pascal_case_title'])
+        if yaml_data.get('globalParameters'):
+            NameConverter._convert_global_parameters(yaml_data['globalParameters'])
+
+    @staticmethod
+    def _convert_global_parameters(global_parameters: List[Dict[str, Any]]) -> None:
+        for global_parameter in global_parameters:
+            NameConverter._convert_language_default_python_case(global_parameter)
+
+    @staticmethod
+    def _convert_operation_groups(operation_groups: List[Dict[str, Any]], code_model_title: str) -> None:
+        for operation_group in operation_groups:
+            NameConverter._convert_language_default_python_case(
+                operation_group, pad_string=PadType.Model, convert_name=True
+            )
+            if not operation_group['language']['default']['name']:
+                operation_group['language']['python']['className'] = code_model_title + "OperationsMixin"
+            else:
+                operation_group_name = operation_group['language']['default']['name']
+                if operation_group_name == 'Operations':
+                    operation_group['language']['python']['className'] = operation_group_name
+                else:
+                    operation_group['language']['python']['className'] = operation_group_name + "Operations"
+            for operation in operation_group['operations']:
+                NameConverter._convert_language_default_python_case(operation, pad_string=PadType.Method)
+                for exception in operation.get('exceptions', []):
+                    NameConverter._convert_language_default_python_case(exception)
+                for parameter in operation.get("parameters", []):
+                    NameConverter._convert_language_default_python_case(parameter, pad_string=PadType.Parameter)
+                for request in operation.get("requests", []):
+                    NameConverter._convert_language_default_python_case(request)
+                    for parameter in request.get("parameters", []):
+                        NameConverter._convert_language_default_python_case(parameter, pad_string=PadType.Parameter)
+                for response in operation.get("responses", []):
+                    NameConverter._convert_language_default_python_case(response)
+
+    @staticmethod
+    def _convert_schemas(schemas: Dict[str, Any]) -> None:
+        for enum in schemas.get("sealedChoices", []) + schemas.get("choices", []):
+            NameConverter._convert_enum_schema(enum)
+        for obj in schemas.get("objects", []) + schemas.get("groups", []):
+            NameConverter._convert_object_schema(obj)
+        for type_list, schema_yamls in schemas.items():
+            for schema in schema_yamls:
+                if type_list == "objects":
+                    continue
+                if type_list in ["arrays", "dictionaries"]:
+                    NameConverter._convert_language_default_python_case(schema)
+                    NameConverter._convert_language_default_python_case(schema["elementType"])
+                elif type_list == "constants":
+                    NameConverter._convert_language_default_python_case(schema)
+                    NameConverter._convert_language_default_python_case(schema["value"])
+                    NameConverter._convert_language_default_python_case(schema["valueType"])
+                else:
+                    NameConverter._convert_language_default_python_case(schema)
+
+    @staticmethod
+    def _convert_enum_schema(schema: Dict[str, Any]) -> None:
+        NameConverter._convert_language_default_pascal_case(schema)
+        for choice in schema["choices"]:
+            NameConverter._convert_language_default_python_case(choice, pad_string=PadType.Enum)
+
+    @staticmethod
+    def _convert_object_schema(schema: Dict[str, Any]) -> None:
+        NameConverter._convert_language_default_pascal_case(schema)
+        schema_description = schema["language"]["python"]["description"]
+        if not schema_description:
+            # what is being used for empty ObjectSchema descriptions
+            schema_description = schema["language"]["python"]["name"]
+        if schema_description and schema_description[-1] != ".":
+            schema_description += "."
+        schema["language"]["python"]["description"] = schema_description
+        for prop in schema.get("properties", []):
+            NameConverter._convert_language_default_python_case(schema=prop, pad_string=PadType.Property)
+
+    @staticmethod
+    def _convert_language_default_python_case(
+        schema: Dict[str, Any], *, pad_string: Optional[PadType] = None, convert_name: bool = False
+    ) -> None:
+        if not schema.get("language") or schema["language"].get("python"):
+            return
+        schema['language']['python'] = dict(schema['language']['default'])
+        schema_name = schema['language']['default']['name']
+        schema_python_name = schema['language']['python']['name']
+
+        if not(
+            schema_name == 'content_type' and
+            schema.get('protocol') and
+            schema['protocol'].get('http') and
+            schema['protocol']['http']['in'] == "header"
+        ):
+            # only escaping name if it's not a content_type header parameter
+            schema_python_name = NameConverter._to_valid_python_name(
+                name=schema_name, pad_string=pad_string, convert_name=convert_name
+            )
+        schema['language']['python']['name'] = schema_python_name.lower()
+
+        schema_description = schema["language"]["default"]["description"].strip()
+        if pad_string == PadType.Method and not schema_description and not schema["language"]["default"].get("summary"):
+            schema_description = schema["language"]["python"]["name"]
+        if schema_description and schema_description[-1] != ".":
+            schema_description += "."
+        schema["language"]["python"]["description"] = schema_description
+
+        schema_summary = schema["language"]["python"].get("summary")
+        if schema_summary:
+            schema_summary = schema_summary.strip()
+            if schema_summary[-1] != ".":
+                schema_summary += "."
+            schema["language"]["python"]["summary"] = schema_summary
+
+    @staticmethod
+    def _convert_language_default_pascal_case(schema: Dict[str, Any]) -> None:
+        if schema["language"].get("python"):
+            return
+        schema['language']['python'] = dict(schema['language']['default'])
+
+        schema_description = schema["language"]["default"]["description"].strip()
+
+        schema["language"]["python"]["description"] = schema_description
+
+    @staticmethod
+    def _to_pascal_case(name: str) -> str:
+        name_list = re.split("[^a-zA-Z\\d]", name)
+        name_list = [s[0].upper() + s[1:] if len(s) > 1 else s.upper() for s in name_list]
+        return "".join(name_list)
+
+    @staticmethod
+    def _to_valid_python_name(name: str, *, pad_string: Optional[PadType] = None, convert_name: bool = False) -> str:
+        if not name:
+            return NameConverter._to_python_case(pad_string.value if pad_string else "")
+        escaped_name = NameConverter._get_escaped_reserved_name(
+            NameConverter._to_valid_name(name.replace("-", "_"), ["_"]), pad_string
+        )
+        if convert_name or name != escaped_name:
+            return NameConverter._to_python_case(escaped_name)
+        return escaped_name
+
+    @staticmethod
+    def _to_python_case(name: str) -> str:
+        def replace_upper_characters(m: Match[str]) -> str:
+            match_str = m.group().lower()
+            if m.start() > 0 and name[m.start() - 1] == "_":
+                # we are good if a '_' already exists
+                return match_str
+            # the first letter should not have _
+            prefix = "_" if m.start() > 0 else ""
+
+            # we will add an extra _ if there are multiple upper case chars together
+            next_non_upper_case_char_location = m.start() + len(match_str)
+            if (
+                len(match_str) > 2
+                and len(name) - next_non_upper_case_char_location > 1
+                and name[next_non_upper_case_char_location].isalpha()
+            ):
+
+                return prefix + match_str[: len(match_str) - 1] + "_" + match_str[len(match_str) - 1]
+
+            return prefix + match_str
+        # return re.sub("[A-Z]+", replace_upper_characters, name)
+        return name
+
+    @staticmethod
+    def _get_escaped_reserved_name(name: str, pad_string: Optional[PadType] = None) -> str:
+        if name is None:
+            raise ValueError("The value for name can not be None")
+        try:
+            # check to see if name is reserved for the type of name we are converting
+            pad_string = cast(PadType, pad_string)
+            if pad_string and name.lower() in reserved_words[pad_string]:
+                name += pad_string.value
+            return name
+        except AttributeError:
+            raise ValueError(f"The name {name} is a reserved word and you have not specified a pad string for it.")
+
+    @staticmethod
+    def _remove_invalid_characters(name: str, allowed_characters: List[str]) -> str:
+        name = name.replace("[]", "Sequence")
+        valid_string = "".join([n for n in name if n.isalpha() or n.isdigit() or n in allowed_characters])
+        return valid_string
+
+    @staticmethod
+    def _to_valid_name(name: str, allowed_characters: List[str]) -> str:
+        correct_name = NameConverter._remove_invalid_characters(name, allowed_characters)
+
+        # here we have an empty string or a string that consists only of invalid characters
+        if not correct_name or correct_name[0] in basic_latin_chars.keys():
+            ret_name = ""
+            for c in name:
+                if c in basic_latin_chars.keys():
+                    ret_name += basic_latin_chars[c]
+                else:
+                    ret_name += c
+            correct_name = NameConverter._remove_invalid_characters(ret_name, allowed_characters)
+
+        if not correct_name:
+            raise ValueError(
+                "Property name {} cannot be used as an identifier, as it contains only invalid characters.".format(name)
+            )
+        return correct_name

--- a/autorest/namer/csharp/python_mappings.py
+++ b/autorest/namer/csharp/python_mappings.py
@@ -1,0 +1,174 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+from enum import Enum
+
+basic_latin_chars = {
+    " ": "Space",
+    "!": "ExclamationMark",
+    '"': "QuotationMark",
+    "#": "NumberSign",
+    "$": "DollarSign",
+    "%": "PercentSign",
+    "&": "Ampersand",
+    "'": "Apostrophe",
+    "(": "LeftParenthesis",
+    ")": "RightParenthesis",
+    "*": "Asterisk",
+    "+": "PlusSign",
+    ",": "Comma",
+    "-": "HyphenMinus",
+    ".": "FullStop",
+    "/": "Slash",
+    "0": "Zero",
+    "1": "One",
+    "2": "Two",
+    "3": "Three",
+    "4": "Four",
+    "5": "Five",
+    "6": "Six",
+    "7": "Seven",
+    "8": "Eight",
+    "9": "Nine",
+    ":": "Colon",
+    ";": "Semicolon",
+    "<": "LessThanSign",
+    "=": "EqualSign",
+    ">": "GreaterThanSign",
+    "?": "QuestionMark",
+    "@": "AtSign",
+    "[": "LeftSquareBracket",
+    "\\": "Backslash",
+    "]": "RightSquareBracket",
+    "^": "CircumflexAccent",
+    "`": "GraveAccent",
+    "{": "LeftCurlyBracket",
+    "|": "VerticalBar",
+    "}": "RightCurlyBracket",
+    "~": "Tilde",
+}
+
+class PadType(Enum):
+    Model = "Model"
+    Method = "Method"
+    Parameter = "Parameter"
+    Enum = "Enum"
+    Property = "Property"
+
+_always_reserved = [
+    "and",
+    "as",
+    "assert",
+    "break",
+    "class",
+    "continue",
+    "def",
+    "del",
+    "elif",
+    "else",
+    "except",
+    "exec",
+    "finally",
+    "for",
+    "from",
+    "global",
+    "if",
+    "import",
+    "in",
+    "is",
+    "lambda",
+    "not",
+    "or",
+    "pass",
+    "raise",
+    "return",
+    "try",
+    "while",
+    "with",
+    "yield",
+    "async",
+    "await"
+]
+
+reserved_words = {
+    PadType.Method: [
+        *_always_reserved
+    ],
+    PadType.Parameter: [
+        "self",
+        # these are kwargs we've reserved for our autorest generated operations
+        "content_type",
+        "cls",
+        "polling",
+        "continuation_token",  # for LRO calls
+        # these are transport kwargs
+        # https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md#transport
+        "connection_timeout",
+        "connection_verify",
+        "connection_cert",
+        "connection_data_block_size",
+        "use_env_settings",
+        # the following aren't in the readme, but Xiang said these are also transport kwargs
+        "read_timeout",
+        "proxies",
+        "cookies",
+        # these are policy kwargs
+        # https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/core/azure-core/CLIENT_LIBRARY_DEVELOPER.md#available-policies
+        "base_headers",
+        "headers",
+        "request_id",
+        "auto_request_id",
+        "base_user_agent",
+        "user_agent",
+        "user_agent_overwrite",
+        "user_agent_use_env",
+        "user_agent",
+        "sdk_moniker",
+        "logging_enable",
+        "logger",
+        "response_encoding",
+        "proxies",
+        "raw_request_hook",
+        "raw_response_hook",
+        "network_span_namer",
+        "tracing_attributes",
+        "permit_redirects",
+        "redirect_max",
+        "redirect_remove_headers",
+        "redirect_on_status_codes",
+        "permit_redirects",
+        "redirect_max",
+        "redirect_remove_headers",
+        "redirect_on_status_codes",
+        "retry_total",
+        "retry_connect",
+        "retry_read",
+        "retry_status",
+        "retry_backoff_factor",
+        "retry_backoff_max",
+        "retry_mode",
+        "retry_on_status_codes",
+        "retry_total",
+        "retry_connect",
+        "retry_read",
+        "retry_status",
+        "retry_backoff_factor",
+        "retry_backoff_max",
+        "retry_mode",
+        "retry_on_status_codes",
+        *_always_reserved
+    ],
+    PadType.Model: [
+        *_always_reserved
+    ],
+    PadType.Property: [
+        "self",
+        *_always_reserved
+    ],
+    PadType.Enum: [
+        "mro",
+        *_always_reserved
+    ]
+}

--- a/config/csharp/readme.md
+++ b/config/csharp/readme.md
@@ -11,32 +11,33 @@ pass-thru:
   - subset-reducer
 # version: 3.0.6258
 use-extension:
-  "@autorest/modelerfour": "4.13.351"
+  "@autorest/modelerfour": "4.15.396"
 
 modelerfour:
   group-parameters: true
   flatten-models: true
   flatten-payloads: true
-  resolve-schema-name-collisons: true
+#  resolve-schema-name-collisons: true
   always-create-content-type-parameter: true
-  multiple-request-parameter-flattening: false
-  naming:
-    parameter: snakecase
-    property: snakecase
-    operation: snakecase
-    operationGroup:  pascalcase
-    choice:  pascalcase
-    choiceValue:  snakecase
-    constant:  snakecase
-    constantParameter:  snakecase
-    type:  pascalcase
-    local: _ + snakecase
-    global: snakecase
-    preserve-uppercase-max-length: 6
-    override:
-      $host: $host
-      base64: base64
-      IncludeAPIs: include_apis
+#  multiple-request-parameter-flattening: false
+#  always-create-content-type-parameter: true
+#  naming:
+#    parameter: snakecase
+#    property: snakecase
+#    operation: snakecase
+#    operationGroup:  pascalcase
+#    choice:  pascalcase
+#    choiceValue:  snakecase
+#    constant:  snakecase
+#    constantParameter:  snakecase
+#    type:  pascalcase
+#    local: _ + snakecase
+#    global: snakecase
+#    preserve-uppercase-max-length: 6
+#    override:
+#      $host: $host
+#      base64: base64
+#      IncludeAPIs: include_apis
 
 
 pipeline:
@@ -54,11 +55,11 @@ pipeline:
   python/m2r:
     input: modelerfour/identity
 
-  python/namer:
+  python/namercsharp:
     input: python/m2r
 
   python/codegen:
-    input: python/namer
+    input: python/namercsharp
     output-artifact: python-files
 
   python/codegen/emitter:


### PR DESCRIPTION
* name `.csproj` file based on the parent namespace
* add .vscode extensions file
* Create a csharp-namer specific plugin and use in the csharp flow - right now mostly just copied from python, will adjust/simplify as needed.  (yes, says "python" all over the place, this is due to how the models code works.